### PR TITLE
Refactor subTreeFor

### DIFF
--- a/src/Chae/Tree.elm
+++ b/src/Chae/Tree.elm
@@ -237,10 +237,10 @@ subTreeFor' id ( tree, ancestors ) =
                             subMatches =
                                 subTreeFor' id (nest child)
                         in
-                            if (List.length (subMatches |> snd)) > 0 then
-                                subMatches
-                            else
+                            if List.isEmpty (subMatches |> snd) then
                                 acc
+                            else
+                                subMatches
                     )
                     ( [], [] )
                     tree

--- a/src/Chae/Tree.elm
+++ b/src/Chae/Tree.elm
@@ -182,7 +182,7 @@ First argument is `Maybe Id` is ether:
 - `Nothing` => result is given tree (with empty ancestors `List`).
 - `Just parentId` => result is sub tree for node with `id == parentId`.
 
-Returns tuple containing sub tree and list of ancestors (paratenrs of root `Node`).
+Returns tuple containing sub tree and list of ancestors of `Node`.
 
     items =
         [ { id = 1, name = "first", parentIds = [] }
@@ -214,33 +214,33 @@ subTreeFor maybeId tree =
 
 
 subTreeFor' : Id -> ( Tree a, List a ) -> ( Tree a, List a )
-subTreeFor' id ( tree, accestors ) =
+subTreeFor' id ( tree, ancestors ) =
     let
         matches =
             List.filter (\n -> Node.id n == id) tree
 
-        subMatches node =
+        nest node =
             let
                 ( _, item, children ) =
                     Node.toTuple node
             in
-                subTreeFor' id ( children, item :: accestors )
+                ( children, item :: ancestors )
     in
         case (List.head matches) of
             Just node ->
-                let
-                    ( _, item, children ) =
-                        Node.toTuple node
-                in
-                    ( children, item :: accestors )
+                nest node
 
             Nothing ->
                 List.foldr
                     (\child acc ->
-                        if (List.length (subMatches child |> fst)) > 0 then
-                            subMatches child
-                        else
-                            acc
+                        let
+                            subMatches =
+                                subTreeFor' id (nest child)
+                        in
+                            if (List.length (subMatches |> snd)) > 0 then
+                                subMatches
+                            else
+                                acc
                     )
                     ( [], [] )
                     tree

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+/elm-stuff/

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,0 +1,13 @@
+port module Main exposing (..)
+
+import Tests
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+
+
+main : Program Never
+main =
+    run emit Tests.all
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,0 +1,80 @@
+module Tests exposing (..)
+
+import Test exposing (..)
+import Expect
+import String
+import Chae.Tree exposing (..)
+import Chae.Node exposing (node)
+
+
+all : Test
+all =
+    describe "Tree"
+        [ subTreeForTests ]
+
+
+subTreeForTests : Test
+subTreeForTests =
+    let
+        items =
+            [ { id = 1, name = "first", parentIds = [] }
+            , { id = 2, name = "child", parentIds = [ 1 ] }
+            , { id = 3, name = "dep categories", parentIds = [ 2 ] }
+            ]
+
+        toId id =
+            toString id
+
+        itemId item =
+            toId (.id item)
+
+        itemParentIds item =
+            .parentIds item |> List.map toId
+
+        tree =
+            fromList itemId itemParentIds items
+    in
+        describe "subTreeFor"
+            [ test "no id" <|
+                \() ->
+                    Expect.equal (subTreeFor Nothing tree) ( tree, [] )
+            , test "root id" <|
+                \() ->
+                    Expect.equal
+                        (subTreeFor (Just "1") tree)
+                        ( [ node
+                                "2"
+                                { id = 2, name = "child", parentIds = [ 1 ] }
+                                ([ node
+                                    "3"
+                                    { id = 3, name = "dep categories", parentIds = [ 2 ] }
+                                    []
+                                 ]
+                                )
+                          ]
+                        , [ { id = 1, name = "first", parentIds = [] } ]
+                        )
+            , test "id the middle of the tree" <|
+                \() ->
+                    Expect.equal
+                        (subTreeFor (Just "2") tree)
+                        ( [ node
+                                "3"
+                                { id = 3, name = "dep categories", parentIds = [ 2 ] }
+                                []
+                          ]
+                        , [ { id = 2, name = "child", parentIds = [ 1 ] }
+                          , { id = 1, name = "first", parentIds = [] }
+                          ]
+                        )
+            , test "leaf id" <|
+                \() ->
+                    Expect.equal
+                        (subTreeFor (Just "3") tree)
+                        ( []
+                        , [ { id = 3, name = "dep categories", parentIds = [ 2 ] }
+                          , { id = 2, name = "child", parentIds = [ 1 ] }
+                          , { id = 1, name = "first", parentIds = [] }
+                          ]
+                        )
+            ]

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -1,0 +1,17 @@
+{
+    "version": "1.0.0",
+    "summary": "Sample Elm Test",
+    "repository": "https://github.com/user/project.git",
+    "license": "BSD-3-Clause",
+    "source-directories": [
+        ".",
+        "../src"
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
+    },
+    "elm-version": "0.17.0 <= v < 0.18.0"
+}


### PR DESCRIPTION
I read `subTreeFor` in order to understand how it works and I saw an opportunity for refactoring to improve readability but it turned into a few related changes:

1. I converted the tests mentioned in the comments into actual tests
0. I refactored `subTreeFor'` by extracting the nesting step used in both `case` branches into a helper function
0. The recursive step was applied two times (it looked wasteful assuming there are no compiler optimizitations, I didn't investigate that), I save the result in `let` block and re-use it
0. This removed the need for the original helper function `subMatches`
0. By adding the last logical test case (leaf id) I discovered a bug (the ancestry lsit was not returened) and fixed it
0. Few fixed typos